### PR TITLE
bugfix for fetching query results

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"time"
 
-        "github.com/sql-machine-learning/sqlflow/gohive/service-rpc/gen-go/tcliservice"
+	"github.com/sql-machine-learning/sqlflow/gohive/service-rpc/gen-go/tcliservice"
 )
 
 // rowSet implements the interface database/sql/driver.Rows.
@@ -20,10 +20,10 @@ type rowSet struct {
 	columns    []*tcliservice.TColumnDesc
 	columnStrs []string
 
-        offset    int
-	rowSet    *tcliservice.TRowSet
+	offset int
+	rowSet *tcliservice.TRowSet
 
-        // resultSet is column-oriented storage format
+	// resultSet is column-oriented storage format
 	resultSet [][]interface{}
 	status    *Status
 }
@@ -45,24 +45,24 @@ func (r *rowSet) Next(dest []driver.Value) error {
 	if !r.status.isFinished() {
 		return fmt.Errorf("job failed.")
 	}
-        // First execution or reach the end of the current result set.
-        if r.resultSet == nil || r.offset >= len(r.resultSet[0]) {
-                r.offset = 0
-	        r.batchFetch()
-        }
+	// First execution or reach the end of the current result set.
+	if r.resultSet == nil || r.offset >= len(r.resultSet[0]) {
+		r.offset = 0
+		r.batchFetch()
+	}
 
 	if len(r.resultSet) <= 0 {
 		return fmt.Errorf("the length of resultSet is not greater than zero.")
 	}
-        // Fill in dest with one single row data.
+	// Fill in dest with one single row data.
 	for colIndex, values := range r.resultSet {
-                // Reach to the end of the last result set.
-                if len(values) == 0 {
-                        return io.EOF
-                }
+		// Reach to the end of the last result set.
+		if len(values) == 0 {
+			return io.EOF
+		}
 		dest[colIndex] = values[r.offset]
 	}
-        r.offset++
+	r.offset++
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (r *rowSet) Close() (err error) {
 }
 
 func (r *rowSet) ColumnTypeDatabaseTypeName(i int) string {
-        return r.columns[i].TypeDesc.Types[0].PrimitiveEntry.Type.String()
+	return r.columns[i].TypeDesc.Types[0].PrimitiveEntry.Type.String()
 }
 
 // Issue a thrift call to check for the job's current status.

--- a/rows.go
+++ b/rows.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/sql-machine-learning/sqlflow/gohive/service-rpc/gen-go/tcliservice"
+        "github.com/sql-machine-learning/sqlflow/gohive/service-rpc/gen-go/tcliservice"
 )
 
 // rowSet implements the interface database/sql/driver.Rows.
@@ -20,9 +20,10 @@ type rowSet struct {
 	columns    []*tcliservice.TColumnDesc
 	columnStrs []string
 
-	offset    int
+        offset    int
 	rowSet    *tcliservice.TRowSet
-	hasMore   bool
+
+        // resultSet is column-oriented storage format
 	resultSet [][]interface{}
 	status    *Status
 }
@@ -44,20 +45,24 @@ func (r *rowSet) Next(dest []driver.Value) error {
 	if !r.status.isFinished() {
 		return fmt.Errorf("job failed.")
 	}
-	if r.resultSet == nil || r.offset >= len(r.resultSet[0]) {
-		if r.hasMore {
-			r.batchFetch()
-		} else {
-			return io.EOF
-		}
-	}
+        // First execution or reach the end of the current result set.
+        if r.resultSet == nil || r.offset >= len(r.resultSet[0]) {
+                r.offset = 0
+	        r.batchFetch()
+        }
+
 	if len(r.resultSet) <= 0 {
 		return fmt.Errorf("the length of resultSet is not greater than zero.")
 	}
-	for i, v := range r.resultSet {
-		dest[i] = v[r.offset]
+        // Fill in dest with one single row data.
+	for colIndex, values := range r.resultSet {
+                // Reach to the end of the last result set.
+                if len(values) == 0 {
+                        return io.EOF
+                }
+		dest[colIndex] = values[r.offset]
 	}
-	r.offset++
+        r.offset++
 	return nil
 }
 
@@ -78,7 +83,6 @@ func (r *rowSet) Columns() []string {
 		for i, col := range r.columns {
 			ret[i] = col.ColumnName
 		}
-
 		r.columnStrs = ret
 	}
 	return r.columnStrs
@@ -89,7 +93,7 @@ func (r *rowSet) Close() (err error) {
 }
 
 func (r *rowSet) ColumnTypeDatabaseTypeName(i int) string {
-	return r.columns[i].TypeDesc.Types[0].PrimitiveEntry.Type.String()
+        return r.columns[i].TypeDesc.Types[0].PrimitiveEntry.Type.String()
 }
 
 // Issue a thrift call to check for the job's current status.
@@ -141,7 +145,6 @@ func (r *rowSet) wait() error {
 }
 
 func (r *rowSet) batchFetch() error {
-	r.offset = 0
 	fetchReq := tcliservice.NewTFetchResultsReq()
 	fetchReq.OperationHandle = r.operation
 	fetchReq.Orientation = tcliservice.TFetchOrientation_FETCH_NEXT
@@ -154,9 +157,7 @@ func (r *rowSet) batchFetch() error {
 	if !isSuccessStatus(resp.Status) {
 		return fmt.Errorf("FetchResults failed: %s\n", resp.Status.String())
 	}
-	r.offset = 0
 	r.rowSet = resp.GetResults()
-	r.hasMore = *resp.HasMoreRows
 
 	rs := r.rowSet.Columns
 	colLen := len(rs)
@@ -216,5 +217,5 @@ func newRows(thrift *tcliservice.TCLIServiceClient,
 	operation *tcliservice.TOperationHandle,
 	options Options) driver.Rows {
 	return &rowSet{thrift, operation, options, nil, nil,
-		0, nil, true, nil, nil}
+		0, nil, nil, nil}
 }


### PR DESCRIPTION
For the field HasMoreRows in TFetchResultsResponse always return false in hiveserver2, in order to fetch query results data through multiple requests, instead, we check if the value in resultSet is empty to judge if there is more data to be fetched.
This bug has been recorded in https://issues.apache.org/jira/browse/HIVE-11631?jql=project%20%3D%20HIVE%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22HasMoreRows%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC three year ago and still open.