### PR TITLE
Move redirect index.html from the sql-machine-learning repo to here

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<meta name="go-import" content="sqlflow.org/gohive git https://github.com/sql-machine-learning/gohive">
+<meta http-equiv="refresh" content="0; url=https://github.com/sql-machine-learning/gohive" />
+<link rel="canonical" href="https://github.com/sql-machine-learning/gohive" />
+<script>
+	window.location.replace("https:\/\/github.com\/sql-machine-learning\/gohive");
+</script>
+</head>
+<body>
+	<h1>Redirecting to <a href="https://github.com/sql-machine-learning/gohive">https://github.com/sql-machine-learning/gohive</a></h1>
+</body>
+</html>


### PR DESCRIPTION
Following the idea https://github.com/sql-machine-learning/sql-machine-learning.github.io/pull/36/files#diff-04c6e90faac2675aa89e2176d2eec7d8R20, I am moving the go-import redirect index.html files from the Web site repo into this repo.  This move is reasonable because each subdirectory containing .go files needs an index.html file, i.e., the directory hierarchy of index.html files must be the same as that in the source repo.  I suffered from the burden that when I canonicalize the directory structure of this repo in https://github.com/sql-machine-learning/gohive/pull/8, I had to change the directory hierarchy of https://github.com/sql-machine-learning/sql-machine-learning.github.io/tree/master/gohive accordingly.  This reminds me that it is more reasonable to put index.html files in this repo and to add a git-submodule in the Web site repo pointing to this repo.