### PR TITLE
support session configuration

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -54,11 +54,11 @@ func (d drv) Open(dsn string) (driver.Conn, error) {
 			s.Password = &cfg.Passwd
 		}
 	}
+	config := cfg.SessionCfg
 	if cfg.DBName != "" {
-		config := make(map[string]string)
 		config["use:database"] = cfg.DBName
-		s.Configuration = config
 	}
+	s.Configuration = config
 	session, err := client.OpenSession(context.Background(), s)
 	if err != nil {
 		return nil, err

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -6,6 +6,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseDSNWithSessionConf(t *testing.T) {
+	sc := make(map[string]string)
+	sc["mapreduce_job_quenename"] = "mr"
+	cfg := &Config{
+		User:       "usr",
+		Passwd:     "pswd",
+		Addr:       "hiveserver",
+		DBName:     "mydb",
+		Auth:       "PLAIN",
+		SessionCfg: sc,
+	}
+	dsn := cfg.FormatDSN()
+	assert.Equal(t, dsn, "usr:pswd@hiveserver/mydb?auth=PLAIN&session.mapreduce_job_quenename=mr")
+
+	cfg2, e := ParseDSN(dsn)
+	assert.Nil(t, e)
+	assert.Equal(t, cfg.User, cfg2.User)
+	assert.Equal(t, cfg.Passwd, cfg2.Passwd)
+	assert.Equal(t, cfg.Addr, cfg2.Addr)
+	assert.Equal(t, cfg.DBName, cfg2.DBName)
+	assert.Equal(t, cfg.Auth, cfg2.Auth)
+	sc, sc2 := cfg.SessionCfg, cfg2.SessionCfg
+	assert.Equal(t, len(sc), len(sc2))
+	for k, v := range sc {
+		v2, found := sc2[k]
+		assert.True(t, found)
+		assert.Equal(t, v, v2)
+	}
+}
+
 func TestParseDSNWithAuth(t *testing.T) {
 	cfg, e := ParseDSN("root:root@127.0.0.1/mnist?auth=PLAIN")
 	assert.Nil(t, e)


### PR DESCRIPTION
data source example: `usr:pswd@hiveserver/mydb?auth=PLAIN&session.mapreduce_job_quenename=mr`
Notice: a session attribute **MUST** starts with `session.` (including a dot)