### PR TITLE
sql support placeholder

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -11,8 +11,9 @@ import (
 
 // hiveOptions for opened Hive sessions.
 type hiveOptions struct {
-	PollIntervalSeconds int64
-	BatchSize           int64
+	PollIntervalSeconds     int64
+	BatchSize               int64
+	ColumnsWithoutTableName bool // column names not contains table name
 }
 
 type hiveConnection struct {

--- a/driver.go
+++ b/driver.go
@@ -66,7 +66,11 @@ func (d drv) Open(dsn string) (driver.Conn, error) {
 		return nil, err
 	}
 
-	options := hiveOptions{PollIntervalSeconds: 5, BatchSize: int64(cfg.Batch)}
+	options := hiveOptions{
+		PollIntervalSeconds:     5,
+		BatchSize:               int64(cfg.Batch),
+		ColumnsWithoutTableName: cfg.ColumnsWithoutTableName,
+	}
 	conn := &hiveConnection{
 		thrift:             client,
 		session:            session.SessionHandle,

--- a/driver.go
+++ b/driver.go
@@ -68,10 +68,11 @@ func (d drv) Open(dsn string) (driver.Conn, error) {
 
 	options := hiveOptions{PollIntervalSeconds: 5, BatchSize: int64(cfg.Batch)}
 	conn := &hiveConnection{
-		thrift:  client,
-		session: session.SessionHandle,
-		options: options,
-		ctx:     context.Background(),
+		thrift:             client,
+		session:            session.SessionHandle,
+		options:            options,
+		ctx:                context.Background(),
+		paramsInterpolator: NewParamsInterpolator(),
 	}
 	return conn, nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -2,6 +2,7 @@ package gohive
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"os"
 	"reflect"
@@ -160,6 +161,14 @@ func TestExec(t *testing.T) {
 	a := assert.New(t)
 	db, _ := newDB("churn")
 	_, err := db.Exec("insert into churn.test (gender) values ('Female')")
+	defer db.Close()
+	a.NoError(err)
+}
+
+func TestExecArgs(t *testing.T) {
+	a := assert.New(t)
+	db, _ := newDB("churn")
+	_, err := db.Exec("insert into churn.test (gender) values (?)", []driver.Value{"Female"})
 	defer db.Close()
 	a.NoError(err)
 }

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -117,3 +117,15 @@ func TestFormatDSNWithoutDBName(t *testing.T) {
 	ds2 := cfg.FormatDSN()
 	assert.Equal(t, ds2, ds)
 }
+
+func TestFormatDSNColumnsWithoutTableNameName(t *testing.T) {
+	ds := "user:passwd@127.0.0.1?columns_without_table_name=true"
+	cfg, e := ParseDSN(ds)
+	assert.Nil(t, e)
+	assert.True(t, cfg.ColumnsWithoutTableName)
+
+	ds2 := "user:passwd@127.0.0.1"
+	cfg2, e := ParseDSN(ds2)
+	assert.Nil(t, e)
+	assert.False(t, cfg2.ColumnsWithoutTableName)
+}

--- a/params_replacer.go
+++ b/params_replacer.go
@@ -134,7 +134,7 @@ func appendBytes(buf, v []byte) []byte {
 }
 
 func appendDateTime(buf []byte, t time.Time) []byte {
-	buf = t.In(time.UTC).AppendFormat(buf, "2006-01-02 15:04:05")
+	buf = t.AppendFormat(buf, "2006-01-02 15:04:05")
 	return buf
 }
 

--- a/params_replacer.go
+++ b/params_replacer.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+const (
+	TimeStampLayout = "2006-01-02 15:04:05.999999999"
+	DateLayout      = "2006-01-02"
+)
+
 type ParamsInterpolator struct {
 	Local *time.Location
 }
@@ -134,7 +139,7 @@ func appendBytes(buf, v []byte) []byte {
 }
 
 func appendDateTime(buf []byte, t time.Time) []byte {
-	buf = t.AppendFormat(buf, "2006-01-02 15:04:05")
+	buf = t.AppendFormat(buf, TimeStampLayout)
 	return buf
 }
 

--- a/params_replacer.go
+++ b/params_replacer.go
@@ -1,0 +1,196 @@
+package gohive
+
+import (
+	"database/sql/driver"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ParamsInterpolator struct {
+	Local *time.Location
+}
+
+func NewParamsInterpolator() *ParamsInterpolator {
+	return &ParamsInterpolator{
+		Local: time.Local,
+	}
+}
+
+func (p *ParamsInterpolator) InterpolateNamedValue(query string, namedArgs []driver.NamedValue) (string, error) {
+	args, err := namedValueToValue(namedArgs)
+	if err != nil {
+		return "", err
+	}
+	return p.Interpolate(query, args)
+}
+
+func (p *ParamsInterpolator) Interpolate(query string, args []driver.Value) (string, error) {
+	if strings.Count(query, "?") != len(args) {
+		return "", fmt.Errorf("gohive driver: number of ? [%d] must be equal to len(args): [%d]",
+			strings.Count(query, "?"), len(args))
+	}
+
+	var err error
+
+	argIdx := 0
+	var buf = make([]byte, 0, len(query)+len(args)*15)
+	for i := 0; i < len(query); i++ {
+		q := strings.IndexByte(query[i:], '?')
+		if q == -1 {
+			buf = append(buf, query[i:]...)
+			break
+		}
+		buf = append(buf, query[i:i+q]...)
+		i += q
+
+		arg := args[argIdx]
+		argIdx++
+
+		buf, err = p.interpolateOne(buf, arg)
+		if err != nil {
+			return "", fmt.Errorf("gohive driver: failed to interpolate failed: %w, args[%d]: [%v]",
+				err, argIdx, arg)
+		}
+
+	}
+	if argIdx != len(args) {
+		return "", fmt.Errorf("gohive driver: args are not all filled into SQL, argIdx: %d, total: %d",
+			argIdx, len(args))
+	}
+	return string(buf), nil
+
+}
+
+func (p *ParamsInterpolator) interpolateOne(buf []byte, arg driver.Value) ([]byte, error) {
+	if arg == nil {
+		buf = append(buf, "NULL"...)
+		return buf, nil
+	}
+
+	switch v := arg.(type) {
+	case int64:
+		buf = strconv.AppendInt(buf, v, 10)
+	case uint64:
+		// Handle uint64 explicitly because our custom ConvertValue emits unsigned values
+		buf = strconv.AppendUint(buf, v, 10)
+	case float64:
+		buf = strconv.AppendFloat(buf, v, 'g', -1, 64)
+	case bool:
+		if v {
+			buf = append(buf, "'true'"...)
+		} else {
+			buf = append(buf, "'false'"...)
+		}
+	case time.Time:
+		if v.IsZero() {
+			buf = append(buf, "'0000-00-00'"...)
+		} else {
+			buf = append(buf, '\'')
+			buf = appendDateTime(buf, v.In(p.Local))
+			buf = append(buf, '\'')
+		}
+	case json.RawMessage:
+		buf = append(buf, '\'')
+		buf = appendBytes(buf, v)
+		buf = append(buf, '\'')
+	case []byte:
+		if v == nil {
+			buf = append(buf, "NULL"...)
+		} else {
+			buf = append(buf, "X'"...)
+			buf = appendBytes(buf, v)
+			buf = append(buf, '\'')
+		}
+	case string:
+		buf = append(buf, '\'')
+		buf = escapeStringBackslash(buf, v)
+		buf = append(buf, '\'')
+	default:
+		return nil, fmt.Errorf("gohive driver: unexpected args type: %T", arg)
+	}
+	return buf, nil
+}
+
+func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
+	args := make([]driver.Value, len(named))
+	for n, param := range named {
+		if len(param.Name) > 0 {
+			return nil, fmt.Errorf("gohive driver: driver does not support the use of Named Parameters")
+		}
+		args[n] = param.Value
+	}
+	return args, nil
+}
+
+func appendBytes(buf, v []byte) []byte {
+	pos := len(buf)
+	buf = reserveBuffer(buf, len(v)+hex.EncodedLen(len(v)))
+	pos += hex.Encode(buf[pos:], v)
+	return buf[:pos]
+}
+
+func appendDateTime(buf []byte, t time.Time) []byte {
+	buf = t.In(time.UTC).AppendFormat(buf, "2006-01-02 15:04:05")
+	return buf
+}
+
+func escapeStringBackslash(buf []byte, v string) []byte {
+	pos := len(buf)
+	buf = reserveBuffer(buf, len(v)*2)
+
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		switch c {
+		case '\x00':
+			buf[pos+1] = '0'
+			buf[pos] = '\\'
+			pos += 2
+		case '\n':
+			buf[pos+1] = 'n'
+			buf[pos] = '\\'
+			pos += 2
+		case '\r':
+			buf[pos+1] = 'r'
+			buf[pos] = '\\'
+			pos += 2
+		case '\x1a':
+			buf[pos+1] = 'Z'
+			buf[pos] = '\\'
+			pos += 2
+		case '\'':
+			buf[pos+1] = '\''
+			buf[pos] = '\\'
+			pos += 2
+		case '"':
+			buf[pos+1] = '"'
+			buf[pos] = '\\'
+			pos += 2
+		case '\\':
+			buf[pos+1] = '\\'
+			buf[pos] = '\\'
+			pos += 2
+		default:
+			buf[pos] = c
+			pos++
+		}
+	}
+
+	return buf[:pos]
+}
+
+// reserveBuffer checks cap(buf) and expand buffer to len(buf) + appendSize.
+// If cap(buf) is not enough, reallocate new buffer.
+func reserveBuffer(buf []byte, appendSize int) []byte {
+	newSize := len(buf) + appendSize
+	if cap(buf) < newSize {
+		// Grow buffer exponentially
+		newBuf := make([]byte, len(buf)*2+appendSize)
+		copy(newBuf, buf)
+		buf = newBuf
+	}
+	return buf[:newSize]
+}

--- a/params_replacer_test.go
+++ b/params_replacer_test.go
@@ -53,13 +53,13 @@ func TestParamsInterpolator_Interpolate(t *testing.T) {
 		{
 			name: "string bytes time zone",
 			fields: fields{
-				Local: time.Local,
+				Local: shanghaiLoc,
 			},
 			args: args{
 				query: "INSERT INTO table_name (field1, field2, field3) VALUES (?, ?, ?,?);",
 				args:  []driver.Value{int64(1), string("\"hello\""), []byte("123abc&()"), time.Date(2024, 5, 5, 0, 0, 0, 0, shanghaiLoc)},
 			},
-			want:    "INSERT INTO table_name (field1, field2, field3) VALUES (1, '\\\"hello\\\"', X'313233616263262829','2024-05-04 16:00:00');",
+			want:    "INSERT INTO table_name (field1, field2, field3) VALUES (1, '\\\"hello\\\"', X'313233616263262829','2024-05-05 00:00:00');",
 			wantErr: assert.NoError,
 		},
 		{

--- a/params_replacer_test.go
+++ b/params_replacer_test.go
@@ -1,0 +1,102 @@
+package gohive
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParamsInterpolator_Interpolate(t *testing.T) {
+	shanghaiLoc, err := time.LoadLocation("Asia/Shanghai")
+	assert.NoError(t, err)
+	type fields struct {
+		Local *time.Location
+	}
+	type args struct {
+		query string
+		args  []driver.Value
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "number of ? [1] must be equal to len(args): [2]",
+			fields: fields{
+				Local: time.Local,
+			},
+			args: args{
+				query: "SELECT * FROM table_name WHERE id = ?;",
+				args:  []driver.Value{int64(1), string("123")},
+			},
+			want:    "",
+			wantErr: assert.Error,
+		},
+		{
+			name: "int",
+			fields: fields{
+				Local: time.Local,
+			},
+			args: args{
+				query: "SELECT * FROM table_name WHERE id = ?;",
+				args:  []driver.Value{int64(1)},
+			},
+			want:    "SELECT * FROM table_name WHERE id = 1;",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "string bytes time zone",
+			fields: fields{
+				Local: time.Local,
+			},
+			args: args{
+				query: "INSERT INTO table_name (field1, field2, field3) VALUES (?, ?, ?,?);",
+				args:  []driver.Value{int64(1), string("\"hello\""), []byte("123abc&()"), time.Date(2024, 5, 5, 0, 0, 0, 0, shanghaiLoc)},
+			},
+			want:    "INSERT INTO table_name (field1, field2, field3) VALUES (1, '\\\"hello\\\"', X'313233616263262829','2024-05-04 16:00:00');",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "\\",
+			fields: fields{
+				Local: time.Local,
+			},
+			args: args{
+				query: "UPDATE table_name SET field1 = ?, field2 = ? WHERE id = ?;",
+				args:  []driver.Value{int64(1), string("\"hello\""), []byte("123")},
+			},
+			want:    "UPDATE table_name SET field1 = 1, field2 = '\\\"hello\\\"' WHERE id = X'313233';",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "\\\\\\",
+			fields: fields{
+				Local: time.Local,
+			},
+			args: args{
+				query: "DELETE FROM table_name WHERE id = ?;",
+				args:  []driver.Value{string(`abc \\\&&&`)},
+			},
+			want:    "DELETE FROM table_name WHERE id = 'abc \\\\\\\\\\\\&&&';",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ParamsInterpolator{
+				Local: tt.fields.Local,
+			}
+			got, err := p.Interpolate(tt.args.query, tt.args.args)
+			if !tt.wantErr(t, err, fmt.Sprintf("Interpolate(%v, %v)", tt.args.query, tt.args.args)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "Interpolate(%v, %v)", tt.args.query, tt.args.args)
+		})
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"time"
 
 	hiveserver2 "sqlflow.org/gohive/hiveserver2/gen-go/tcliservice"
@@ -86,11 +87,23 @@ func (r *rowSet) Columns() []string {
 		}
 		ret := make([]string, len(r.columns))
 		for i, col := range r.columns {
+			if r.options.ColumnsWithoutTableName {
+				ret[i] = columnRemoveTable(col.ColumnName)
+				continue
+			}
 			ret[i] = col.ColumnName
 		}
 		r.columnStrs = ret
 	}
 	return r.columnStrs
+}
+
+func columnRemoveTable(n string) string {
+	index := strings.Index(n, ".")
+	if index == -1 {
+		return n
+	}
+	return n[index+1:]
 }
 
 func (r *rowSet) Close() (err error) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,51 @@
+package gohive
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_columnRemoveTable(t *testing.T) {
+	type args struct {
+		n string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "",
+			args: args{
+				n: "t.name",
+			},
+			want: "name",
+		},
+		{
+			name: "",
+			args: args{
+				n: "name",
+			},
+			want: "name",
+		},
+		{
+			name: "",
+			args: args{
+				n: "",
+			},
+			want: "",
+		},
+		{
+			name: "",
+			args: args{
+				n: ".",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, columnRemoveTable(tt.args.n), "columnRemoveTable(%v)", tt.args.n)
+		})
+	}
+}


### PR DESCRIPTION
sql support placeholder

example: 
```
db.Exec("insert into churn.test (gender) values (?)", []driver.Value{"Female"})
```

At present, simple types are supported, and complex types (such as array map struct) will be supported in a few days